### PR TITLE
Adding advanced snapshot

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sensor_msgs)
 
-find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs actionlib_msgs message_generation std_msgs)
 
 # For point_cloud2.py
 catkin_python_setup()
@@ -46,7 +46,13 @@ add_service_files(
   SnapshotCloud.srv
   SnapshotImage.srv)
 
-generate_messages(DEPENDENCIES geometry_msgs std_msgs)
+add_action_files(
+  DIRECTORY action
+  FILES
+  AdvancedSnapshotCloud.action
+)
+
+generate_messages(DEPENDENCIES geometry_msgs std_msgs actionlib_msgs)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/sensor_msgs/action/AdvancedSnapshotCloud.action
+++ b/sensor_msgs/action/AdvancedSnapshotCloud.action
@@ -4,7 +4,10 @@ bool dense_cloud
 # exposure in milliseconds (0 indicates autoexposure)
 uint32 exposure
 
-bool raw_data
+uint8 raw_data
+uint8 NO_RAW_DATA = 0
+uint8 GRAYSCALE = 1
+uint8 RGB = 2
 
 ---
 

--- a/sensor_msgs/action/AdvancedSnapshotCloud.action
+++ b/sensor_msgs/action/AdvancedSnapshotCloud.action
@@ -1,0 +1,19 @@
+# dense_cloud = true, if the cloud has to be dense (ordered)
+bool dense_cloud
+
+# exposure in milliseconds (0 indicates autoexposure)
+uint32 exposure
+
+bool raw_data
+
+---
+
+# cloud is the returning point cloud
+sensor_msgs/PointCloud2 cloud
+
+# image is the 2d data form the camera
+sensor_msgs/Image image
+
+---
+
+uint32 percentage_completed

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -15,10 +15,12 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
 
   <export>
     <architecture_independent/>


### PR DESCRIPTION
This new action allow an advanced way to substract camera information. 
-First of all, it is a action to allow a compute time (not possible to control in service) time between asking the image and the response. This is necessary if you want to apply flexview in Ensenso.
-Second, it allows to call 2d information apart from the pointcloud.